### PR TITLE
Fix homepage initialization and autoplay

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx } from "https://esm.sh/react/jsx-runtime";
 import ReactDOM from "https://esm.sh/react-dom@18.2.0/client";
 import App from "./App";
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
     const root = document.getElementById('react-root');
     if (root) {
         ReactDOM.createRoot(root).render(_jsx(App, {}));
@@ -17,4 +17,10 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log('Autoplay prevented');
         });
     }
-});
+}
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+}
+else {
+    init();
+}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="dist/style.css">
 </head>
 <body>
-    <audio id="bg-music" src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3" loop></audio>
+     <audio id="bg-music" src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3" loop autoplay></audio>
     <header>
         <h1 class="logo">Srineet</h1>
         <nav>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from "https://esm.sh/react-dom@18.2.0/client";
 import App from "./App";
 
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
   const root = document.getElementById('react-root');
   if (root) {
     ReactDOM.createRoot(root).render(<App />);
@@ -19,4 +19,11 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('Autoplay prevented');
     });
   }
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+


### PR DESCRIPTION
## Summary
- Ensure React app and audio initialization run immediately when DOM is ready
- Autoplay background audio on load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896543606448321bd18bd778c35b19f