### PR TITLE
Add React-based background music player

### DIFF
--- a/dist/MusicPlayer.js
+++ b/dist/MusicPlayer.js
@@ -1,0 +1,29 @@
+import { jsx as _jsx } from "https://esm.sh/react/jsx-runtime";
+import { useEffect, useRef, useState } from "https://esm.sh/react";
+export default function MusicPlayer() {
+    const audioRef = useRef(null);
+    const [playing, setPlaying] = useState(true);
+    useEffect(() => {
+        audioRef.current = new Audio("https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3");
+        audioRef.current.loop = true;
+        audioRef.current.volume = 0.4;
+        audioRef.current.play().catch(() => setPlaying(false));
+        return () => {
+            audioRef.current?.pause();
+            audioRef.current = null;
+        };
+    }, []);
+    function toggle() {
+        if (!audioRef.current)
+            return;
+        if (playing) {
+            audioRef.current.pause();
+            setPlaying(false);
+        }
+        else {
+            audioRef.current.play();
+            setPlaying(true);
+        }
+    }
+    return (_jsx("button", { onClick: toggle, "aria-label": "Toggle background music", children: playing ? "Pause Music" : "Play Music" }));
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,6 +1,7 @@
 import { jsx as _jsx } from "https://esm.sh/react/jsx-runtime";
 import ReactDOM from "https://esm.sh/react-dom@18.2.0/client";
 import App from "./App";
+import MusicPlayer from "./MusicPlayer";
 function init() {
     const root = document.getElementById('react-root');
     if (root) {
@@ -10,12 +11,9 @@ function init() {
     toggle?.addEventListener('click', () => {
         document.body.classList.toggle('dark-mode');
     });
-    const audio = document.getElementById('bg-music');
-    if (audio) {
-        audio.volume = 0.4;
-        audio.play().catch(() => {
-            console.log('Autoplay prevented');
-        });
+    const musicRoot = document.getElementById('music-player-root');
+    if (musicRoot) {
+        ReactDOM.createRoot(musicRoot).render(_jsx(MusicPlayer, {}));
     }
 }
 if (document.readyState === 'loading') {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="dist/style.css">
 </head>
 <body>
-     <audio id="bg-music" src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3" loop autoplay></audio>
     <header>
         <h1 class="logo">Srineet</h1>
         <nav>
@@ -131,6 +130,7 @@
     <section id="music">
         <h2>Music</h2>
         <p>Enjoy the ambient soundtrack playing in the background while you browse.</p>
+        <div id="music-player-root"></div>
     </section>
 
     <section id="contact">

--- a/src/MusicPlayer.tsx
+++ b/src/MusicPlayer.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from "https://esm.sh/react";
+
+export default function MusicPlayer() {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [playing, setPlaying] = useState(true);
+
+  useEffect(() => {
+    audioRef.current = new Audio("https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3");
+    audioRef.current.loop = true;
+    audioRef.current.volume = 0.4;
+    audioRef.current.play().catch(() => setPlaying(false));
+    return () => {
+      audioRef.current?.pause();
+      audioRef.current = null;
+    };
+  }, []);
+
+  function toggle() {
+    if (!audioRef.current) return;
+    if (playing) {
+      audioRef.current.pause();
+      setPlaying(false);
+    } else {
+      audioRef.current.play();
+      setPlaying(true);
+    }
+  }
+
+  return (
+    <button onClick={toggle} aria-label="Toggle background music">
+      {playing ? "Pause Music" : "Play Music"}
+    </button>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from "https://esm.sh/react-dom@18.2.0/client";
 import App from "./App";
+import MusicPlayer from "./MusicPlayer";
 
 function init() {
   const root = document.getElementById('react-root');
@@ -12,12 +13,9 @@ function init() {
     document.body.classList.toggle('dark-mode');
   });
 
-  const audio = document.getElementById('bg-music') as HTMLAudioElement | null;
-  if (audio) {
-    audio.volume = 0.4;
-    audio.play().catch(() => {
-      console.log('Autoplay prevented');
-    });
+  const musicRoot = document.getElementById('music-player-root');
+  if (musicRoot) {
+    ReactDOM.createRoot(musicRoot).render(<MusicPlayer />);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace static audio tag with React MusicPlayer component
- mount MusicPlayer via new `music-player-root` for global audio control

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896569370cc8321ae966343f5c85a80